### PR TITLE
chore(admin): set published field to false by default

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -25,7 +25,7 @@ collections:
       - { label: 'Arquivo', name: 'podcast_file', widget: 'string', required: false }
       - { label: 'Duração', name: 'podcast_duration', widget: 'string', required: false }
       - { label: 'Tamanho (em bytes)', name: 'podcast_bytes', widget: 'string', required: false }
-      - { label: 'Publicado', name: 'published', widget: 'boolean', required: false }
+      - { label: 'Publicado', name: 'published', widget: 'boolean', default: false }
       - { label: 'Youtube', name: 'youtube', widget: 'string', required: false }
       - label: 'Corpo'
         name: 'body'


### PR DESCRIPTION
Closes https://github.com/triceratops-show/www.triceratops.show/issues/40

The thing here is that if there's no `published` field, hugo assumes it should be published.
So if you don't interact with the `published` box, it will simply consider it undefined and therefore it will be published.

This PR forces the field to be false.