### PR TITLE
Populate podcast bytes duration field

### DIFF
--- a/assets/js/admin.jsx
+++ b/assets/js/admin.jsx
@@ -1,6 +1,5 @@
 import CMS from "decap-cms-app";
 import React from "react";
-import jsmediatags from "./node_modules/jsmediatags/dist/jsmediatags.min";
 import { initPodcastBytes } from "./podcast_bytes_hook";
 import { initPodcastDuration } from "./podcast_duration_hook";
 
@@ -48,22 +47,6 @@ if (window.CSS_PATH) {
   CMS.registerPreviewTemplate("episodios", EpisodesPreview);
 }
 
-function FooFunction() {
-  // Return a custom upload component
-  // That hits an api
-  // That api uploads to s3
-  // And returns a path that will populate
-  // podcast_file: "/episodios/episodio-64.mp3"
-  //
-  // We also need to populate the following fields
-  // podcast_duration: "1:13:46"
-  // podcast_bytes: 177025093
-
-  return <div>function component xd</div>;
-}
-
-//CMS.registerWidget("foo", FooFunction);
-
 // Dirty but works
 //const localDomains = ["localhost", "office"];
 const localDomains = ["localhost"];
@@ -96,6 +79,5 @@ if (localDomains.includes(window.location.hostname)) {
 
 const MP3_PREFIX = "https://www.triceratops.show";
 
-console.log("before calling");
 initPodcastBytes(CMS, MP3_PREFIX);
 initPodcastDuration(CMS, MP3_PREFIX);

--- a/assets/js/admin.jsx
+++ b/assets/js/admin.jsx
@@ -1,5 +1,8 @@
 import CMS from "decap-cms-app";
 import React from "react";
+import jsmediatags from "./node_modules/jsmediatags/dist/jsmediatags.min";
+import { initPodcastBytes } from "./podcast_bytes_hook";
+import { initPodcastDuration } from "./podcast_duration_hook";
 
 // TODO keep this in sync with layouts/partials/episode.html
 class EpisodesPreview extends React.Component {
@@ -59,7 +62,7 @@ function FooFunction() {
   return <div>function component xd</div>;
 }
 
-CMS.registerWidget("foo", FooFunction);
+//CMS.registerWidget("foo", FooFunction);
 
 // Dirty but works
 //const localDomains = ["localhost", "office"];
@@ -90,3 +93,9 @@ if (localDomains.includes(window.location.hostname)) {
     },
   });
 }
+
+const MP3_PREFIX = "https://www.triceratops.show";
+
+console.log("before calling");
+initPodcastBytes(CMS, MP3_PREFIX);
+initPodcastDuration(CMS, MP3_PREFIX);

--- a/assets/js/admin.jsx
+++ b/assets/js/admin.jsx
@@ -45,6 +45,22 @@ if (window.CSS_PATH) {
   CMS.registerPreviewTemplate("episodios", EpisodesPreview);
 }
 
+function FooFunction() {
+  // Return a custom upload component
+  // That hits an api
+  // That api uploads to s3
+  // And returns a path that will populate
+  // podcast_file: "/episodios/episodio-64.mp3"
+  //
+  // We also need to populate the following fields
+  // podcast_duration: "1:13:46"
+  // podcast_bytes: 177025093
+
+  return <div>function component xd</div>;
+}
+
+CMS.registerWidget("foo", FooFunction);
+
 // Dirty but works
 //const localDomains = ["localhost", "office"];
 const localDomains = ["localhost"];

--- a/assets/js/podcast_bytes_hook.js
+++ b/assets/js/podcast_bytes_hook.js
@@ -1,0 +1,42 @@
+async function getContentLength(filename) {
+  return new Promise(async (resolve, reject) => {
+    // TODO: error validation
+    const response = await fetch(filename, {
+      method: "HEAD",
+    });
+
+    const contentLength = response.headers.get("content-length");
+    console.log({ contentLength });
+    if (!contentLength) {
+      throw new Error("Could not find value of header content-length");
+    }
+    resolve(contentLength);
+  });
+}
+
+export function initPodcastBytes(CMS, MP3_PREFIX) {
+  console.log("initializing 'preSave' event for 'podcast_bytes' populator");
+
+  CMS.registerEventListener({
+    name: "preSave",
+    handler: async function ({ entry }) {
+      let podcastFilename = entry.get("data").get("podcast_file");
+      if (!podcastFilename) {
+        throw new Error("Field 'podcast_file' is required`");
+      }
+      podcastFilename = MP3_PREFIX + podcastFilename;
+
+      let contentLength = entry.get("data").get("podcast_bytes");
+      if (!contentLength) {
+        console.log("Loading mp3 file into memory, it can take a while.");
+        contentLength = await getContentLength(podcastFilename);
+        console.log("Populating podcast_bytes with value", contentLength);
+      } else {
+        console.log(
+          "NOT populating field 'podcast_bytes' since it's already populated."
+        );
+      }
+      return entry.get("data").set("podcast_bytes", contentLength);
+    },
+  });
+}

--- a/assets/js/podcast_duration_hook.js
+++ b/assets/js/podcast_duration_hook.js
@@ -1,0 +1,62 @@
+// It loads the entire file in memory
+// Which is slow
+// But since it should be done only once it's fine
+async function getMp3Duration(filename) {
+  return new Promise((resolve, reject) => {
+    const audioContext = new (window.AudioContext ||
+      window.webkitAudioContext)();
+    const request = new XMLHttpRequest();
+    request.open("GET", filename, true);
+    request.responseType = "arraybuffer";
+    request.onload = function () {
+      audioContext.decodeAudioData(request.response, function (buffer) {
+        let duration = buffer.duration;
+        resolve(toHHMMSS(duration));
+      });
+    };
+    request.send();
+  });
+}
+function toHHMMSS(timeInSeconds) {
+  var sec_num = parseInt(timeInSeconds, 10); // don't forget the second param
+  var hours = Math.floor(sec_num / 3600);
+  var minutes = Math.floor((sec_num - hours * 3600) / 60);
+  var seconds = sec_num - hours * 3600 - minutes * 60;
+
+  if (hours < 10) {
+    hours = "0" + hours;
+  }
+  if (minutes < 10) {
+    minutes = "0" + minutes;
+  }
+  if (seconds < 10) {
+    seconds = "0" + seconds;
+  }
+  return hours + ":" + minutes + ":" + seconds;
+}
+
+export function initPodcastDuration(CMS, MP3_PREFIX) {
+  console.log("initializing 'preSave' event for 'podcast_duration' populator");
+
+  CMS.registerEventListener({
+    name: "preSave",
+    handler: async function ({ entry }) {
+      let podcastFilename = entry.get("data").get("podcast_file");
+      if (!podcastFilename) {
+        throw new Error("Field 'podcast_file' is required`");
+      }
+      podcastFilename = MP3_PREFIX + podcastFilename;
+
+      let contentDuration = entry.get("data").get("podcast_duration");
+      if (!contentDuration) {
+        contentDuration = await getMp3Duration(podcastFilename);
+        console.log("Populating podcast_duration with value", contentDuration);
+      } else {
+        console.log(
+          "NOT populating field 'podcast_duration' since it's already populated."
+        );
+      }
+      return entry.get("data").set("podcast_duration", contentDuration);
+    },
+  });
+}

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -18,15 +18,14 @@ collections:
     sortable_fields: ['episode', 'publishDate']
     fields:
       - { label: 'Episódio', hint: 'número do episódio', name: 'episode', widget: 'number', required: false }
-      - { label: 'foo', name: 'foo', widget: 'foo', required: false }
       - { label: 'Título', name: 'title', widget: 'string', required: false }
       - { label: 'Capa', name: 'image', widget: 'image', required: false }
       - { label: 'Descrição', name: 'description', widget: 'text', required: false }
       - { label: 'Artistas tocados', hint: 'separados por vírgula', name: 'artistas', widget: 'list', required: false }
       - { label: 'Participações', hint: 'separadas por vírgula', name: 'participacoes', widget: 'list', required: false }
       - { label: 'Arquivo', name: 'podcast_file', widget: 'string', required: false }
-      - { label: 'Duração', hint: 'no formato hh:mm:ss', name: 'podcast_duration', widget: 'string', required: false }
-      - { label: 'Tamanho', hint: 'em bytes', name: 'podcast_bytes', widget: 'string', required: false }
+      - { label: 'Duração', hint: 'no formato hh:mm:ss', name: 'podcast_duration', widget: 'hidden', required: false }
+      - { label: 'Tamanho', hint: 'em bytes', name: 'podcast_bytes', widget: 'hidden', required: true }
       - { label: 'YouTube', name: 'youtube', widget: 'string', required: false }
       - { label: 'Publicado', name: 'published', widget: 'boolean', default: false }
       - { label: 'Data de publicação', name: 'publishDate', widget: 'datetime', required: false }

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -18,6 +18,7 @@ collections:
     sortable_fields: ['episode', 'publishDate']
     fields:
       - { label: 'Episódio', hint: 'número do episódio', name: 'episode', widget: 'number', required: false }
+      - { label: 'foo', name: 'foo', widget: 'foo', required: false }
       - { label: 'Título', name: 'title', widget: 'string', required: false }
       - { label: 'Capa', name: 'image', widget: 'image', required: false }
       - { label: 'Descrição', name: 'description', widget: 'text', required: false }

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -24,7 +24,7 @@ collections:
       - { label: 'Artistas tocados', hint: 'separados por vírgula', name: 'artistas', widget: 'list', required: false }
       - { label: 'Participações', hint: 'separadas por vírgula', name: 'participacoes', widget: 'list', required: false }
       - { label: 'Arquivo', name: 'podcast_file', widget: 'string', required: false }
-      - { label: 'Duração', hint: 'no formato hh:mm:ss', name: 'podcast_duration', widget: 'hidden', required: false }
+      - { label: 'Duração', hint: 'no formato hh:mm:ss', name: 'podcast_duration', widget: 'hidden', required: true }
       - { label: 'Tamanho', hint: 'em bytes', name: 'podcast_bytes', widget: 'hidden', required: true }
       - { label: 'YouTube', name: 'youtube', widget: 'string', required: false }
       - { label: 'Publicado', name: 'published', widget: 'boolean', default: false }


### PR DESCRIPTION
Closes https://github.com/triceratops-show/www.triceratops.show/issues/92

It only populates these fields if necessary.
For the `podcast_bytes` we can simply do a HEAD request and check the `content-length` header.
For the `podcast_duration` field, we need to load the entire mp3 into memory, which is slow (eg last episode is 170MB), but since it should be done only once it's fine.